### PR TITLE
Add support for Python 3 and reverting of changes.

### DIFF
--- a/git.plugin
+++ b/git.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=git
 IAge=3
 Name=Git

--- a/git/viewactivatable.py
+++ b/git/viewactivatable.py
@@ -117,7 +117,7 @@ class GitPlugin(GObject.Object, Gedit.ViewActivatable):
                 cwd=os.path.dirname(self.location.get_path()),
                 stdout=PIPE, stderr=PIPE)
             content, err = process.communicate()
-        except Exception, ex:
+        except Exception as ex:
             raise ex
         return content
 
@@ -153,7 +153,7 @@ class GitPlugin(GObject.Object, Gedit.ViewActivatable):
             if last_item[-1:] == '\n':
                 self.file_contents_list[-1] = last_item[:-1]
 
-        except Exception, ex:
+        except Exception as ex:
             # New file in a git repository
             self.file_contents_list = []
 

--- a/git/viewactivatable.py
+++ b/git/viewactivatable.py
@@ -25,12 +25,19 @@ import os
 from subprocess import Popen, PIPE
 
 
-class LineContext:
-    __slots__ = ('removed_lines', 'line_type')
+class LineContext(object):
+    __slots__ = ('removed_lines', 'line_type', 'range')
 
     def __init__(self):
         self.removed_lines = []
         self.line_type = DiffType.NONE
+        self.range = None
+
+    def get_start(self):
+        return self.range[0] - 1
+
+    def get_end(self):
+        return self.range[0] + (self.range[1] if len(self.range) > 1 else 1) - 1
 
 
 class GitPlugin(GObject.Object, Gedit.ViewActivatable):
@@ -217,8 +224,10 @@ class GitPlugin(GObject.Object, Gedit.ViewActivatable):
             if line_data[0] == '@':
                 for token in line_data.split():
                     if token[0] == '+':
-                        hunk_point = int(token.split(',', 1)[0])
                         line_context = LineContext()
+                        line_context.range = tuple(map(int,
+                                                       token[1:].split(",")))
+                        hunk_point = line_context.range[0]
                         break
 
             elif line_data[0] == '-':


### PR DESCRIPTION
It seems some (all?) versions of gedit above 3.8.3 have trouble with
Python 2 plugins and do not support the "python" loader previously
specified in git.plugin.

This pull request also implements the ability to undo changes by clicking in the gutter.
