### PR TITLE
Fix AttributeError: 'Document' object has no attribute 'get_location'

### DIFF
--- a/git/viewactivatable.py
+++ b/git/viewactivatable.py
@@ -129,7 +129,7 @@ class GitPlugin(GObject.Object, Gedit.ViewActivatable):
         return content
 
     def update_location(self, *args):
-        self.location = self.buffer.get_location()
+        self.location = self.buffer.get_file().get_location()
         if self.location is None:
             return
 


### PR DESCRIPTION
git plugin broke sometime late Jan 2022 and won't show colors in gutter.

Found this repo and was getting error message

Traceback (most recent call last):
  File "/home/l/.local/share/gedit/plugins/git/viewactivatable.py", line 132, in update_location
    self.location = self.buffer.get_location()
AttributeError: 'Document' object has no attribute 'get_location'

Found fix at

https://github.com/MicahCarrick/gedit-source-code-browser/issues/35

The object model of gedit has obviously changed.
In the file "plugin.py" you need to replace the code

"document.get_location()"

to

"document.get_file().get_location()"